### PR TITLE
Fixing up github watchers count

### DIFF
--- a/pages/project/[path].js
+++ b/pages/project/[path].js
@@ -45,7 +45,7 @@ function Project({ project, path }) {
             <div className="stats-details">
               <div>
                 <WatchIcon w={18} h={18} />
-                <p>{project.watchers_count}</p>
+                <p>{project.subscribers_count}</p>
               </div>
               <p>watchers</p>
             </div>


### PR DESCRIPTION
Github watchers match stargazers for legacy support. Watcher count is found as subscriber_count on the API.