### PR TITLE
Split playwright workflows into 2

### DIFF
--- a/.github/workflows/playwright-onDemand.yml
+++ b/.github/workflows/playwright-onDemand.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Playwright tests
+
+on:
+  # Runs on push or pull requests
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright
+      run: npx playwright install --with-deps
+    - name: Build production build
+      run: npm run build
+    - name: Run your tests
+      run: npm run test

--- a/.github/workflows/playwright-onDemand.yml
+++ b/.github/workflows/playwright-onDemand.yml
@@ -1,15 +1,26 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# This is a basic workflow to help you get started with Actions
 
 name: Playwright tests
 
+# Controls when the workflow will run
 on:
-  # Runs on push or pull requests
+  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
+    branches: [ "main" ]
   pull_request:
+    branches: [ "main" ]
+  schedule: 
+    # nightly
+    - cron: '0 0 * * *'
+    
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  test:
+    # Runs on an ubuntu runner
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,3 +39,56 @@ jobs:
       run: npm run build
     - name: Run your tests
       run: npm run test
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Upload HTML report as Artifact
+      uses: actions/upload-artifact@v2
+      env:
+          TAG_NAME: test-report-${{ steps.date.outputs.date }}
+      if: always()
+      with: 
+        name: onDemand
+        path: pw-report/
+
+  storeReports:
+    name: Store reports
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v3
+      id: download
+    - name: Publish to external repo
+      if: always()
+      uses: peaceiris/actions-gh-pages@v3.7.3
+      with:
+        external_repository: mspnp/intern-js-pipeline
+        publish_branch: gh-pages
+        personal_token: ${{ secrets.PAT_TOKEN }}
+        publish_dir: ${{steps.download.outputs.download-path}}
+        destination_dir: test-reports/${{ github.repository }}
+        keep_files: true
+        user_name: "github-actions[bot]"
+        user_email: "github-actions[bot]@users.noreply.github.com"
+
+  notify-dashboard:
+    name: Notify Dashboard
+    if: ${{ always() }}
+    needs: [test, storeReports]
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Notify docusaurus repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          gh api repos/mspnp/intern-js-pipeline/dispatches \
+              --raw-field event_type=rebuild-site

--- a/.github/workflows/playwright-onDemand.yml
+++ b/.github/workflows/playwright-onDemand.yml
@@ -7,7 +7,7 @@ on:
   # Runs on push or pull requests
   push:
   pull_request:
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright-scheduled.yml
+++ b/.github/workflows/playwright-scheduled.yml
@@ -4,9 +4,7 @@
 name: Playwright tests
 
 on:
-  # Runs on push or pull requests and nightly
-  push:
-  pull_request:
+  # Runs nightly
   schedule: 
     # nightly
     - cron: '0 0 * * *'

--- a/.github/workflows/playwright-scheduled.yml
+++ b/.github/workflows/playwright-scheduled.yml
@@ -1,16 +1,16 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: Scheduled Playwright tests
 
-name: Playwright tests
-
+# Controls when the workflow will run
 on:
-  # Runs nightly
+  # Triggers the workflow nightly
   schedule: 
     # nightly
     - cron: '0 0 * * *'
 
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  test:
+    # Runs on an ubuntu runner
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,3 +29,56 @@ jobs:
       run: npm run build
     - name: Run your tests
       run: npm run test
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Upload HTML report as Artifact
+      uses: actions/upload-artifact@v2
+      env:
+          TAG_NAME: test-report-${{ steps.date.outputs.date }}
+      if: always()
+      with: 
+        name: ${{ steps.date.outputs.date }}
+        path: pw-report/
+
+  storeReports:
+    name: Store reports
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v3
+      id: download
+    - name: Publish to external repo
+      if: always()
+      uses: peaceiris/actions-gh-pages@v3.7.3
+      with:
+        external_repository: mspnp/intern-js-pipeline
+        publish_branch: gh-pages
+        personal_token: ${{ secrets.PAT_TOKEN }}
+        publish_dir: ${{steps.download.outputs.download-path}}
+        destination_dir: test-reports/${{ github.repository }}
+        keep_files: true
+        user_name: "github-actions[bot]"
+        user_email: "github-actions[bot]@users.noreply.github.com"
+
+  notify-dashboard:
+    name: Notify Dashboard
+    if: ${{ always() }}
+    needs: [test, storeReports]
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Notify dashboard repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          gh api repos/mspnp/intern-js-pipeline/dispatches \
+              --raw-field event_type=rebuild-site

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
     use: {
+        trace: 'on',
         baseURL: "http://localhost:3000/"
     },
     webServer: {
@@ -9,5 +10,10 @@ const config: PlaywrightTestConfig = {
         timeout: 120 * 1000,
         reuseExistingServer: !process.env.CI,
     },
+    reporter: [
+        ['html', { outputFolder: 'pw-report' }], 
+        ['json', { outputFolder: 'pw-report', outputFile: 'report.json' }]
+    ],
+
 };
 export default config;


### PR DESCRIPTION
Split the playwright workflow into 2 separate workflows, one that runs on demand and the other that runs every night. Also updating reporter in playwright config file to store html and json reports in pw-report folder (and turned trace on).