### PR TITLE
fix: add GithubIcon 'w' and 'h' props

### DIFF
--- a/components/Icons.js
+++ b/components/Icons.js
@@ -226,12 +226,12 @@ export function AzureIcon() {
   );
 }
 
-export function GithubIcon() {
+export function GithubIcon({ w, h }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
+      width={w}
+      height={h}
       fill="none"
       viewBox="0 0 24 24"
     >


### PR DESCRIPTION
On line 68 of [path].js:
```jsx
<GithubIcon w={24} h={24} />
```
the props ``w`` and ``h`` are excluded from the definition of GithubIcon (lines 229 - 244 of Icons.js):
```jsx
export function GithubIcon() { // should be GithubIcon({ w, h })
  return (
    <svg
      xmlns="http://www.w3.org/2000/svg"
      width="24" // should be {w}
      height="24" // should be {h}
      fill="none"
      viewBox="0 0 24 24"
    >
      <path
	// ...
	></path>
    </svg>
  );
}
```